### PR TITLE
Substantially revised the ASN.1 in sections 4-6

### DIFF
--- a/draft-xxxxx-pq-composite-certs-x509.mkd
+++ b/draft-xxxxx-pq-composite-certs-x509.mkd
@@ -1,8 +1,8 @@
 ---
-title: Composite Postquantum Keys and Signatures in PKIX Certificates
+title: Composite Post-Quantum Keys and Signatures For Use In Internet PKI
 abbrev: Composite Certs
 # <!-- EDNOTE: Edits the draft name -->
-docname: draft-xxxxx-pq-composite-certs-x509-00<
+docname: draft-xxxxx-pq-composite-certs-x509-00
 # <!-- date: 2012-01-13 -->
 # <!-- date: 2012-01 -->
 # <!-- date: 2012 -->
@@ -49,6 +49,7 @@ informative:
 updates:
   RFC2986
   RFC5280
+# <!-- EDNOTE: Add RFC 3279? -->
 
 --- abstract
 EDNOTE: This will be the abstract
@@ -74,9 +75,7 @@ During the transition to post-quantum cryptography, the deployment of cryptograp
 - Algorithm strength uncertainty: During the transition period, some post-quantum signature and encryption algorithms will not be fully trusted, while also the trust in legacy public key algorithms will also start to erode.  A relying party may learn some time after certificate deployment that a public key algorithm has become untrustworthy, but in the interim, they may not know which algorithm an adversary has compromised.
 - Backwards compatibility: During the transition period, post-quantum algorithms will not be supported by all clients.
 
-This document provides a mechanism to address algorithm strength uncertainty by providing formats for encoding multiple public keys into the existing public key field. The issue of backwards compatibility is left open to be addressed in separate draft(s).
-
-
+This document provides a mechanism to address algorithm strength uncertainty by providing formats for encoding multiple public keys and multiple signature values into existing public key and signature fields. The issue of backwards compatibility is left open to be addressed in separate draft(s).
 
 <!-- End of Introduction section -->
 
@@ -102,40 +101,54 @@ An X.509 certificate conforming to {{RFC5280}}. In particular, a certificate con
 An X.509 certificate containing two or more subject public keys and two or more issuer signatures as defined in this document.
 
 # Composite Structures {#sec-composite-structs}
+~~DESCRIBE DESIGN AND INTENT, SEQUENCE SO WE HAVE 2 OR MORE, BLAH BLAH~~
+This section defines
 
-This section defines general structures for holding multiple subject public keys. ~~DESCRIBE DESIGN AND INTENT, SEQUENCE SO WE HAVE 2 OR MORE, BLAH BLAH~~ This addresses the "algorithm strength uncertainty" concern from {{sec-intro}}, though the authors note that this mechanism may have prove to have utility beyond the post-quantum migration.
+  - A general structure for holding multiple public keys within a single public key data structure.
 
-Defining composite algorithm identifiers in this way avoids the exponential proliferation of OIDs needed for each pairwise combination of signature algorithms. This scheme also naturally extends from 2-keypair to n-keypair should a vendor find a use for this.
+  - Data structures needed to make use of the Composite Signature signature algorithm (defined in {{sec-composite-signature-algorithm}}), which  encapsulates signatures made with multiple public keys.
+  
+These structures can be used to address the "algorithm strength uncertainty" concern from {{sec-intro}}, though the authors note that this mechanism may prove to have utility beyond the post-quantum migration.
 
-## CompositeAlgorithmIdentifier
-
-We define the following new structure:
+## Composite Public Key {#sec-composite-pub-keys}
+A composite public key is a sequence of public keys that are generally used together.  A composite public key is identified by the object identifier
 
 ~~~ asn.1
-CompositeAlgorithmIdentifier ::= SEQUENCE OF AlgorithmIdentifier
+id-ce-compositePublicKey OBJECT IDENTIFIER ::= { OID }
 ~~~
-{: artwork-name="CompositeAlgorithmIdentifier-asn.1-structures"}
+{: artwork-name="CompositePublicKeyOID-asn.1-structures"}
 
-
-## CompositePublicKey {#sec-composite-pub-keys}
-
-We define the following new structure:
+The parameters field for this public key type MUST be absent.  The composite public key data is represented by the following structure:
 
 ~~~ asn.1
-id-ce-CompositeAlgorithmIdentifier OBJECT IDENTIFIER ::= { OID }
-
-CompositeAlgorithmIdentifier ::= SEQUENCE OF AlgorithmIdentifier
+CompositePublicKey ::= SEQUENCE OF SubjectPublicKeyInfo
 ~~~
 {: artwork-name="CompositePublicKey-asn.1-structures"}
 
-The choice of `SEQUENCE OF BIT STRING` rather than `BIT STRING` is so the type-length-value encoding can solve the problem of variable-length public keys.
+where each element of the sequence is a SubjectPublicKeyInfo of a public key that MAY be used in conjunction with the other keys in the sequence.  When the public key must be provided in octet string or bit string format, the data structure is converted as specified in {{sec-encoding-composite-structures}}.
 
-## CompositeSignatureValue {#sec-composite-sigs}
-EDNOTE: This subsection describes the PKIX Composite Signatures and how they work. It will also explain how signing a certificate will work and how verification will work.
+## Composite Signature Algorithm Structures {#sec-composite-sigs}
+The Composite Signature signature algorithm defined in {{sec-composite-signature-algorithm}} is identified by the following object identifier:
 
-This section defines a general structure containing multiple signature values. ~~DESCRIBE DESIGN AND INTENT, SEQUENCE SO WE HAVE 2 OR MORE, BLAH BLAH~~ This addresses the "algorithm strength uncertainty" concern from {{sec-intro}}, though the authors note that this mechanism may have prove to have utility beyond the post-quantum migration.
+~~~ asn.1
+id-ce-compositeSignature OBJECT IDENTIFIER ::= { OID }
+~~~
+{: artwork-name="CompositeSignature-asn.1-structures"}
 
-We define the following new structure:
+The following algorithm parameters MUST be included when this identifier is used:
+
+~~~ asn.1
+CompositeSignatureAlgorithmParams ::= SEQUENCE OF AlgorithmIdentifier
+~~~
+{: artwork-name="CompositeSignatureParams-asn.1-structures"}
+
+The algorithms in the sequence MUST correspond to the order in which the public keys are listed in the associated CompositePublicKey.
+
+EDNOTE: We haven't defined the private key syntax, but I think we should
+
+The Composite Signature algorithm output is the DER encoding of the following structure:
+
+EDNOTE: Does this structure need an OID, or is it sufficient that the algorithm have an OID as defined above?
 
 ~~~ asn.1
 id-ce-CompositeSignatureValue OBJECT IDENTIFIER ::= { OID }
@@ -146,28 +159,33 @@ CompositeSignatureValue ::= SEQUENCE OF BIT STRING
 
 The choice of `SEQUENCE OF BIT STRING` rather than `BIT STRING` is so the type-length-value encoding can solve the problem of variable-length signature values.
 
-## SubjectPublicKeyInfo {#sec-composite-spki}
+Defining composite algorithm parameters as above avoids the exponential proliferation of OIDs needed for each pairwise combination of signature algorithms. This scheme also naturally extends from 2-keypair to n-keypair should a vendor find a use for this.
 
-We re-define the `SubjectPublicKeyInfo` structure from {{RFC5280}} in the following way so that it is backwards-compatible with the definition given in {{RFC2986}} and {{RFC5280}}.
+# Encoding Composite Structures As Octet Strings and Bit Strings {#sec-encoding-composite-structures}
+EDNOTE: Examples of how other specifications specify how a data structure is converted to a bit string can be found in RFC 2313, section 10.1.4, 3279 section 2.3.5, and RFC 4055, section 3.2.
 
-~~~ asn.1
-SubjectPublicKeyInfo  ::=  CHOICE {
-     SEQUENCE  {
-          algorithm            AlgorithmIdentifier,
-          subjectPublicKey     BIT STRING  },
-     SEQUENCE  {
-          algorithms           CompositeAlgorithmIdentifier,
-          subjectPublicKeys    CompositePublicKey }
-      }
-~~~
-{: artwork-name="composite-SubjectPublicKeyInfo-asn.1"}
+Many specifications require that the composite public key and composite signature data structures defined above be represented by an octet string or bit string.  When an octet string is required, the DER encoding of the composite data structure SHALL be used directly.  When a bit string is required, the octets of the DER encoded composite data structure SHALL be used as the bits of the bit string, with the most significant bit of the first octet becoming the first bit, and so on, ending with the least significant bit of the last octet becoming the last bit of the bit string. 
 
-The order MUST be consistent between the `algorithms` and the `subjectPublicKeys`, ie the 0th `CompositeAlgorithmIdentifier` MUST correspond to the 0th `CompositePublicKey` and so on.
+# Composite Signature Signature Algorithm {#sec-composite-signature-algorithm}
+The Composite Signature signature algorithm produces a single composite signature by applying multiple signature algorithms to the input data, using multiple public keys, with the resulting signature effectively being the concatenation of the individual signatures.  This algorithm can address algorithm strength uncertainty by leveraging the strength of all of the signature algorithms used as part of the composite signature.
 
+## Signature Generation
 
+Input:
+
+Output:
+
+Signature Generation Procedure:
+
+## Signature Verification
+
+Input:
+
+Output:
+
+Signature Verification Procedure:
 
 # Composite Certificates {#sec-composite-certs}
-
 We re-define the `Certificate` structure from {{RFC5280}} to use the composite public key and signature structures defined in {{sec-composite-pub-keys}} and {{sec-composite-sigs}}, respectively so that it is backwards-compatible with the definition given in {{RFC5280}}.
 
 
@@ -204,7 +222,7 @@ Some aspects of certificate enrollment need to be modified to accommodate certif
 
 ## PCKS#10 {#sec-p10}
 
-To place multiple public keys into a certificate signing request, the only modification needed to the PKCS#10 format is to replace the definition of `SubjectPublicKeyInfo ` given in {{RFC2986}} with the one given above in {{sec-composite-spki}}, which is backwards-compatible with the previous definition.
+To place multiple public keys into a certificate signing request, the requester can include a public key of type CompositePublicKey ({{sec-composite-pub-keys}})
 
 To place multiple signatures into a certificate signing request, we re-define the `CertificationRequest` from {{RFC2986}}.
 

--- a/draft-xxxxx-pq-composite-certs-x509.txt
+++ b/draft-xxxxx-pq-composite-certs-x509.txt
@@ -4,13 +4,13 @@
 
 XXX WG                                            P. Kampanakis (Editor)
 Internet-Draft                                             Cisco Systems
-Updates: RFC2986 RFC5280 (if approved)                 December 26, 2018
+Updates: RFC2986 RFC5280 (if approved)                  January 11, 2019
 Intended status: Standards Track
-Expires: June 29, 2019
+Expires: July 15, 2019
 
 
-     Composite Postquantum Keys and Signatures in PKIX Certificates
-                draft-xxxxx-pq-composite-certs-x509-00<
+   Composite Post-Quantum Keys and Signatures For Use In Internet PKI
+                 draft-xxxxx-pq-composite-certs-x509-00
 
 Abstract
 
@@ -31,11 +31,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 29, 2019.
+   This Internet-Draft will expire on July 15, 2019.
 
 Copyright Notice
 
-   Copyright (c) 2018 IETF Trust and the persons identified as the
+   Copyright (c) 2019 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -53,51 +53,66 @@ Copyright Notice
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 1]
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 1]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
 Table of Contents
 
-   1.  Change Log  . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   1.  Change Log  . . . . . . . . . . . . . . . . . . . . . . . . .   3
    2.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
-     3.1.  Traditional Certificate . . . . . . . . . . . . . . . . .   3
+     3.1.  Traditional Certificate . . . . . . . . . . . . . . . . .   4
      3.2.  Composite Certificate . . . . . . . . . . . . . . . . . .   4
    4.  Composite Structures  . . . . . . . . . . . . . . . . . . . .   4
-     4.1.  CompositeAlgorithmIdentifier  . . . . . . . . . . . . . .   4
-     4.2.  CompositePublicKey  . . . . . . . . . . . . . . . . . . .   4
-     4.3.  CompositeSignatureValue . . . . . . . . . . . . . . . . .   4
-     4.4.  SubjectPublicKeyInfo  . . . . . . . . . . . . . . . . . .   5
-   5.  Composite Certificates  . . . . . . . . . . . . . . . . . . .   5
-     5.1.  Validation  . . . . . . . . . . . . . . . . . . . . . . .   6
-   6.  Certificate Enrollment  . . . . . . . . . . . . . . . . . . .   6
-     6.1.  PCKS#10 . . . . . . . . . . . . . . . . . . . . . . . . .   6
-     6.2.  Subsequent Enrollments with Overlapping Public Keys . . .   7
-   7.  Certificate Revocation  . . . . . . . . . . . . . . . . . . .   7
-     7.1.  Certificate Revocation Lists (CRLs) . . . . . . . . . . .   7
-       7.1.1.  CertificateList . . . . . . . . . . . . . . . . . . .   8
-       7.1.2.  TBS Cert List . . . . . . . . . . . . . . . . . . . .   8
-     7.2.  Revoking an algorithm: Revoked Algorithms CRL Extension .   9
-     7.3.  Implicit Revocation . . . . . . . . . . . . . . . . . . .  10
-     7.4.  End-Entity Requested Revocation . . . . . . . . . . . . .  11
-   8.  New Algorithm Identifiers . . . . . . . . . . . . . . . . . .  11
-   9.  In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  11
-   10. Implications for existing standards . . . . . . . . . . . . .  12
-     10.1.  RFC 2986 . . . . . . . . . . . . . . . . . . . . . . . .  12
-     10.2.  RFC 5280 . . . . . . . . . . . . . . . . . . . . . . . .  12
-     10.3.  Cryptographic protocols  . . . . . . . . . . . . . . . .  12
-   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
-   12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
-   13. Appendices  . . . . . . . . . . . . . . . . . . . . . . . . .  13
-     13.1.  Comparison with draft-truskovsky-lamps-pq-hybrid-x509  .  13
-   14. Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  13
-   15. Acknowledgenents  . . . . . . . . . . . . . . . . . . . . . .  13
-   16. References  . . . . . . . . . . . . . . . . . . . . . . . . .  13
-     16.1.  Normative References . . . . . . . . . . . . . . . . . .  13
-     16.2.  Informative References . . . . . . . . . . . . . . . . .  14
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  14
+     4.1.  Composite Public Key  . . . . . . . . . . . . . . . . . .   4
+     4.2.  Composite Signature Algorithm Structures  . . . . . . . .   5
+   5.  Encoding Composite Structures As Octet Strings and Bit
+       Strings . . . . . . . . . . . . . . . . . . . . . . . . . . .   5
+   6.  Composite Signature Signature Algorithm . . . . . . . . . . .   6
+     6.1.  Signature Generation  . . . . . . . . . . . . . . . . . .   6
+     6.2.  Signature Verification  . . . . . . . . . . . . . . . . .   6
+   7.  Composite Certificates  . . . . . . . . . . . . . . . . . . .   6
+     7.1.  Validation  . . . . . . . . . . . . . . . . . . . . . . .   7
+   8.  Certificate Enrollment  . . . . . . . . . . . . . . . . . . .   7
+     8.1.  PCKS#10 . . . . . . . . . . . . . . . . . . . . . . . . .   7
+     8.2.  Subsequent Enrollments with Overlapping Public Keys . . .   8
+   9.  Certificate Revocation  . . . . . . . . . . . . . . . . . . .   8
+     9.1.  Certificate Revocation Lists (CRLs) . . . . . . . . . . .   8
+       9.1.1.  CertificateList . . . . . . . . . . . . . . . . . . .   9
+       9.1.2.  TBS Cert List . . . . . . . . . . . . . . . . . . . .   9
+     9.2.  Revoking an algorithm: Revoked Algorithms CRL Extension .  10
+     9.3.  Implicit Revocation . . . . . . . . . . . . . . . . . . .  11
+     9.4.  End-Entity Requested Revocation . . . . . . . . . . . . .  12
+   10. New Algorithm Identifiers . . . . . . . . . . . . . . . . . .  12
+   11. In Practice . . . . . . . . . . . . . . . . . . . . . . . . .  12
+   12. Implications for existing standards . . . . . . . . . . . . .  13
+     12.1.  RFC 2986 . . . . . . . . . . . . . . . . . . . . . . . .  13
+     12.2.  RFC 5280 . . . . . . . . . . . . . . . . . . . . . . . .  13
+     12.3.  Cryptographic protocols  . . . . . . . . . . . . . . . .  13
+   13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
+   14. Security Considerations . . . . . . . . . . . . . . . . . . .  13
+   15. Appendices  . . . . . . . . . . . . . . . . . . . . . . . . .  14
+     15.1.  Comparison with draft-truskovsky-lamps-pq-hybrid-x509  .  14
+   16. Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  14
+   17. Acknowledgenents  . . . . . . . . . . . . . . . . . . . . . .  14
+   18. References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
+     18.1.  Normative References . . . . . . . . . . . . . . . . . .  14
+     18.2.  Informative References . . . . . . . . . . . . . . . . .  15
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  15
+
+
+
+
+
+
+
+
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 2]
+
+Internet-Draft               Composite Certs                January 2019
+
 
 1.  Change Log
 
@@ -106,13 +121,6 @@ Table of Contents
    draft-xxxxx-pq-composite-certs-x509-00
 
    o  Beginning of the draft
-
-
-
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 2]
-
-Internet-Draft               Composite Certs               December 2018
-
 
 2.  Introduction
 
@@ -135,8 +143,9 @@ Internet-Draft               Composite Certs               December 2018
 
    This document provides a mechanism to address algorithm strength
    uncertainty by providing formats for encoding multiple public keys
-   into the existing public key field.  The issue of backwards
-   compatibility is left open to be addressed in separate draft(s).
+   and multiple signature values into existing public key and signature
+   fields.  The issue of backwards compatibility is left open to be
+   addressed in separate draft(s).
 
 3.  Terminology
 
@@ -152,6 +161,15 @@ Internet-Draft               Composite Certs               December 2018
 
    o  Composite certificate
 
+
+
+
+
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 3]
+
+Internet-Draft               Composite Certs                January 2019
+
+
    EDNOTE: Look up the standard way to do glossaries in RFCs.  EDNOTE:
    I'm not sure we actually need these terms in this draft.  We'll
    certainly need them in the Parallel PKIs draft.
@@ -162,14 +180,6 @@ Internet-Draft               Composite Certs               December 2018
    certificate containing a single subject public key, and a single
    issuer signature.
 
-
-
-
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 3]
-
-Internet-Draft               Composite Certs               December 2018
-
-
 3.2.  Composite Certificate
 
    An X.509 certificate containing two or more subject public keys and
@@ -177,59 +187,71 @@ Internet-Draft               Composite Certs               December 2018
 
 4.  Composite Structures
 
-   This section defines general structures for holding multiple subject
-   public keys. ~~DESCRIBE DESIGN AND INTENT, SEQUENCE SO WE HAVE 2 OR
-   MORE, BLAH BLAH~~ This addresses the "algorithm strength uncertainty"
-   concern from Section 2, though the authors note that this mechanism
-   may have prove to have utility beyond the post-quantum migration.
+   ~~DESCRIBE DESIGN AND INTENT, SEQUENCE SO WE HAVE 2 OR MORE, BLAH
+   BLAH~~ This section defines
 
-   Defining composite algorithm identifiers in this way avoids the
-   exponential proliferation of OIDs needed for each pairwise
-   combination of signature algorithms.  This scheme also naturally
-   extends from 2-keypair to n-keypair should a vendor find a use for
-   this.
+   o  A general structure for holding multiple public keys within a
+      single public key data structure.
 
-4.1.  CompositeAlgorithmIdentifier
+   o  Data structures needed to make use of the Composite Signature
+      signature algorithm (defined in Section 6), which encapsulates
+      signatures made with multiple public keys.
 
-   We define the following new structure:
-
-   CompositeAlgorithmIdentifier ::= SEQUENCE OF AlgorithmIdentifier
-
-4.2.  CompositePublicKey
-
-   We define the following new structure:
-
-   id-ce-CompositeAlgorithmIdentifier OBJECT IDENTIFIER ::= { OID }
-
-   CompositeAlgorithmIdentifier ::= SEQUENCE OF AlgorithmIdentifier
-
-   The choice of "SEQUENCE OF BIT STRING" rather than "BIT STRING" is so
-   the type-length-value encoding can solve the problem of variable-
-   length public keys.
-
-4.3.  CompositeSignatureValue
-
-   EDNOTE: This subsection describes the PKIX Composite Signatures and
-   how they work.  It will also explain how signing a certificate will
-   work and how verification will work.
-
-   This section defines a general structure containing multiple
-   signature values. ~~DESCRIBE DESIGN AND INTENT, SEQUENCE SO WE HAVE 2
-   OR MORE, BLAH BLAH~~ This addresses the "algorithm strength
+   These structures can be used to address the "algorithm strength
    uncertainty" concern from Section 2, though the authors note that
-
-
-
-
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 4]
-
-Internet-Draft               Composite Certs               December 2018
-
-
-   this mechanism may have prove to have utility beyond the post-quantum
+   this mechanism may prove to have utility beyond the post-quantum
    migration.
 
-   We define the following new structure:
+4.1.  Composite Public Key
+
+   A composite public key is a sequence of public keys that are
+   generally used together.  A composite public key is identified by the
+   object identifier
+
+   id-ce-compositePublicKey OBJECT IDENTIFIER ::= { OID }
+
+   The parameters field for this public key type MUST be absent.  The
+   composite public key data is represented by the following structure:
+
+   CompositePublicKey ::= SEQUENCE OF SubjectPublicKeyInfo
+
+   where each element of the sequence is a SubjectPublicKeyInfo of a
+   public key that MAY be used in conjunction with the other keys in the
+   sequence.  When the public key must be provided in octet string or
+
+
+
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 4]
+
+Internet-Draft               Composite Certs                January 2019
+
+
+   bit string format, the data structure is converted as specified in
+   Section 5.
+
+4.2.  Composite Signature Algorithm Structures
+
+   The Composite Signature signature algorithm defined in Section 6 is
+   identified by the following object identifier:
+
+   id-ce-compositeSignature OBJECT IDENTIFIER ::= { OID }
+
+   The following algorithm parameters MUST be included when this
+   identifier is used:
+
+   CompositeSignatureAlgorithmParams ::= SEQUENCE OF AlgorithmIdentifier
+
+   The algorithms in the sequence MUST correspond to the order in which
+   the public keys are listed in the associated CompositePublicKey.
+
+   EDNOTE: We haven't defined the private key syntax, but I think we
+   should
+
+   The Composite Signature algorithm output is the DER encoding of the
+   following structure:
+
+   EDNOTE: Does this structure need an OID, or is it sufficient that the
+   algorithm have an OID as defined above?
 
    id-ce-CompositeSignatureValue OBJECT IDENTIFIER ::= { OID }
 
@@ -239,31 +261,82 @@ Internet-Draft               Composite Certs               December 2018
    the type-length-value encoding can solve the problem of variable-
    length signature values.
 
-4.4.  SubjectPublicKeyInfo
+   Defining composite algorithm parameters as above avoids the
+   exponential proliferation of OIDs needed for each pairwise
+   combination of signature algorithms.  This scheme also naturally
+   extends from 2-keypair to n-keypair should a vendor find a use for
+   this.
 
-   We re-define the "SubjectPublicKeyInfo" structure from [RFC5280] in
-   the following way so that it is backwards-compatible with the
-   definition given in [RFC2986] and [RFC5280].
+5.  Encoding Composite Structures As Octet Strings and Bit Strings
 
-   SubjectPublicKeyInfo  ::=  CHOICE {
-        SEQUENCE  {
-             algorithm            AlgorithmIdentifier,
-             subjectPublicKey     BIT STRING  },
-        SEQUENCE  {
-             algorithms           CompositeAlgorithmIdentifier,
-             subjectPublicKeys    CompositePublicKey }
-         }
+   EDNOTE: Examples of how other specifications specify how a data
+   structure is converted to a bit string can be found in RFC 2313,
+   section 10.1.4, 3279 section 2.3.5, and RFC 4055, section 3.2.
 
-   The order MUST be consistent between the "algorithms" and the
-   "subjectPublicKeys", ie the 0th "CompositeAlgorithmIdentifier" MUST
-   correspond to the 0th "CompositePublicKey" and so on.
 
-5.  Composite Certificates
+
+
+
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 5]
+
+Internet-Draft               Composite Certs                January 2019
+
+
+   Many specifications require that the composite public key and
+   composite signature data structures defined above be represented by
+   an octet string or bit string.  When an octet string is required, the
+   DER encoding of the composite data structure SHALL be used directly.
+   When a bit string is required, the octets of the DER encoded
+   composite data structure SHALL be used as the bits of the bit string,
+   with the most significant bit of the first octet becoming the first
+   bit, and so on, ending with the least significant bit of the last
+   octet becoming the last bit of the bit string.
+
+6.  Composite Signature Signature Algorithm
+
+   The Composite Signature signature algorithm produces a single
+   composite signature by applying multiple signature algorithms to the
+   input data, using multiple public keys, with the resulting signature
+   effectively being the concatenation of the individual signatures.
+   This algorithm can address algorithm strength uncertainty by
+   leveraging the strength of all of the signature algorithms used as
+   part of the composite signature.
+
+6.1.  Signature Generation
+
+   Input:
+
+   Output:
+
+   Signature Generation Procedure:
+
+6.2.  Signature Verification
+
+   Input:
+
+   Output:
+
+   Signature Verification Procedure:
+
+7.  Composite Certificates
 
    We re-define the "Certificate" structure from [RFC5280] to use the
-   composite public key and signature structures defined in Section 4.2
-   and Section 4.3, respectively so that it is backwards-compatible with
+   composite public key and signature structures defined in Section 4.1
+   and Section 4.2, respectively so that it is backwards-compatible with
    the definition given in [RFC5280].
+
+
+
+
+
+
+
+
+
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 6]
+
+Internet-Draft               Composite Certs                January 2019
+
 
    Certificate  ::=  SEQUENCE  {
         tbsCertificate       TBSCertificate,
@@ -274,13 +347,6 @@ Internet-Draft               Composite Certs               December 2018
              BIT STRING,
              CompositeSignatureValue }
        }
-
-
-
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 5]
-
-Internet-Draft               Composite Certs               December 2018
-
 
    If either the "signatureAlgorithm" or "signatureValue" field contains
    the composite version, then the other MUST as well.  The order MUST
@@ -294,48 +360,38 @@ Internet-Draft               Composite Certs               December 2018
    "CompositePublicKey"", being specific about which tags and length
    values are included in the hash.
 
-5.1.  Validation
+7.1.  Validation
 
    EDNOTE: talk about how composite certs are validated.  Specifically
    address what happens if a client supports only some of the algs.  Do
    we need to bring in a "SHOULD contain exactly 2 signatures, but MAY
    contain an arbitrary number if the vendor has a client-policy
    mechanism by which they can specify an algorithm verification policy"
-   in Section 4.3 ?
+   in Section 4.2 ?
 
    EDNOTE: reference {sec-revokedalgorithms}
 
    EDNOTE: be consistent through this doc "validation" vs "verificiton"
 
-6.  Certificate Enrollment
+8.  Certificate Enrollment
 
    Some aspects of certificate enrollment need to be modified to
    accommodate certificates with composite public keys and signatures.
 
-6.1.  PCKS#10
+8.1.  PCKS#10
 
    To place multiple public keys into a certificate signing request, the
-   only modification needed to the PKCS#10 format is to replace the
-   definition of "SubjectPublicKeyInfo " given in [RFC2986] with the one
-   given above in Section 4.4, which is backwards-compatible with the
-   previous definition.
+   requester can include a public key of type CompositePublicKey
+   (Section 4.1)
 
    To place multiple signatures into a certificate signing request, we
    re-define the "CertificationRequest" from [RFC2986].
 
 
 
-
-
-
-
-
-
-
-
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 6]
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 7]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    CertificationRequest ::= SEQUENCE {
@@ -359,7 +415,7 @@ Internet-Draft               Composite Certs               December 2018
    Needs a thorough read-through of RFC2986 for other things that might
    need modification.
 
-6.2.  Subsequent Enrollments with Overlapping Public Keys
+8.2.  Subsequent Enrollments with Overlapping Public Keys
 
    Once an entity in the PKI has a valid composite certificate, it MAY
    send subsequent certificate enrollment requests for traditional
@@ -372,7 +428,7 @@ Internet-Draft               Composite Certs               December 2018
    later than the expiry date of the referenced composite certificate
    with the {earliest expiry date?, latest expiry date?}.
 
-7.  Certificate Revocation
+9.  Certificate Revocation
 
    EDNOTE: This subsection will talk about compromises of keys,
    revocation and how recovation will be verified.
@@ -381,7 +437,7 @@ Internet-Draft               Composite Certs               December 2018
    (MUST?) check each key individually, not a bit-for-bit match of the
    entire "CompositePublicKey" field.
 
-7.1.  Certificate Revocation Lists (CRLs)
+9.1.  Certificate Revocation Lists (CRLs)
 
    EDNOTE: A mention to OCSP implications should be made.
 
@@ -389,9 +445,9 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 7]
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 8]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    EDNOTE: The mechanism for globally revoking an algorithm should be
@@ -405,10 +461,10 @@ Internet-Draft               Composite Certs               December 2018
    purpose requirements may build on this profile or may replace it."
    ... include a sentence with the same language that we are doing this.
 
-7.1.1.  CertificateList
+9.1.1.  CertificateList
 
    We re-define the "CertificateList" structure from [RFC5280] to use
-   the composite signature structure defined in Section 4.3 so that it
+   the composite signature structure defined in Section 4.2 so that it
    is backwards-compatible with the definition given in [RFC5280].
 
    CertificateList  ::=  SEQUENCE  {
@@ -422,15 +478,15 @@ Internet-Draft               Composite Certs               December 2018
 
    The "signatureAlgorithm" field MUST contain the same algorithm
    identifier as the signature field in the sequence tbsCertList
-   Section 7.1.2.
+   Section 9.1.2.
 
    EDNOTE: should echo / update the text in RFC5280: 5.1.1.2.
    signatureAlgorithm, and 5.1.1.3.  signatureValue
 
-7.1.2.  TBS Cert List
+9.1.2.  TBS Cert List
 
    We re-define the "TBSCertList" structure from [RFC5280] to use the
-   composite signature structure defined in Section 4.3 so that it is
+   composite signature structure defined in Section 4.2 so that it is
    backwards-compatible with the definition given in [RFC5280].
 
    TBSCertList  ::=  SEQUENCE  {
@@ -445,9 +501,9 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 8]
+Kampanakis (Editor)       Expires July 15, 2019                 [Page 9]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    The "..." indicates that all other fields retain their definitions
@@ -455,9 +511,9 @@ Internet-Draft               Composite Certs               December 2018
 
    The "signature" field MUST contain the same algorithm identifier as
    the signatureAlgorithm field in the sequence CertificateList
-   Section 7.1.1.
+   Section 9.1.1.
 
-7.2.  Revoking an algorithm: Revoked Algorithms CRL Extension
+9.2.  Revoking an algorithm: Revoked Algorithms CRL Extension
 
    Since a certificate may contain public keys and / or signatures, it
    is conceivable that even though a cryptographic algorithm is
@@ -501,9 +557,9 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                 [Page 9]
+Kampanakis (Editor)       Expires July 15, 2019                [Page 10]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    been valid had those Algorithm IDs and Signature Values been omitted
@@ -531,7 +587,7 @@ Internet-Draft               Composite Certs               December 2018
    mechanisms (this does not apply when the algorithm is globally
    revoked for the entire scope of this CRL).
 
-7.3.  Implicit Revocation
+9.3.  Implicit Revocation
 
    A certificate is considered to be "implicitly revoked" if one of the
    following conditions are met, but the certificate is otherwise valid.
@@ -557,16 +613,16 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                [Page 10]
+Kampanakis (Editor)       Expires July 15, 2019                [Page 11]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    EDNOTE: read up on how OCSP works and mention the specific mechanism
    for the above.  Also, is it the OCSP Responder's responsibility or
    the client's to check this?
 
-7.4.  End-Entity Requested Revocation
+9.4.  End-Entity Requested Revocation
 
    EDNOTE: Before drafting this section, there's a debate to be had
    about whether a single-key revocation request has the authority to
@@ -591,13 +647,13 @@ Internet-Draft               Composite Certs               December 2018
    EDNOTE: We may need to wade into modifications to the CMP / SCEP /
    EST protocols (but I really hope not).
 
-8.  New Algorithm Identifiers
+10.  New Algorithm Identifiers
 
    EDNOTE: This subsection defines the OIDs for the initial composite
    algorithm combinations we want to define.  EDNOTE: Merge with
-   Section 11 ??
+   Section 13 ??
 
-9.  In Practice
+11.  In Practice
 
    EDNOTE: This section will talk about practical issue of how these
    certificates will be used.  For example it will talk about the size
@@ -613,22 +669,22 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                [Page 11]
+Kampanakis (Editor)       Expires July 15, 2019                [Page 12]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
-10.  Implications for existing standards
+12.  Implications for existing standards
 
-10.1.  RFC 2986
+12.1.  RFC 2986
 
    EDNOTE: summarize the updates to RFC 2986 (CSR / PKCS#10).
 
-10.2.  RFC 5280
+12.2.  RFC 5280
 
    EDNOTE: summarize the updates to RFC 5280 (X.509).
 
-10.3.  Cryptographic protocols
+12.3.  Cryptographic protocols
 
    EDNOTE: This section talks about how protocols like (D)TLS and IKEv2
    are affected by this specifications.  It will not attempt to solve
@@ -638,9 +694,9 @@ Internet-Draft               Composite Certs               December 2018
    will describe how signature_algorithms extension will be used in TLS.
    What is missing in TLS and IKEv2 like what and how to sign something
    with the two private keys.  It will discuss overhead (size and
-   processing) as in Section 9.  It will also discuss PKCS#10.
+   processing) as in Section 11.  It will also discuss PKCS#10.
 
-11.  IANA Considerations
+13.  IANA Considerations
 
    EDNOTE: This section will include content only if new OIDs or IANA
    codepoints are asigned for it.
@@ -656,7 +712,7 @@ Internet-Draft               Composite Certs               December 2018
 
    o  CompositeSignatureValue
 
-12.  Security Considerations
+14.  Security Considerations
 
    EDNOTE: This section includes the Security Considerations.
 
@@ -669,18 +725,18 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                [Page 12]
+Kampanakis (Editor)       Expires July 15, 2019                [Page 13]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    o  CA implementations need to be careful when checking for
       compromised key reuse: unpack the CompositePublicKey structure and
       compare individual keys.
 
-13.  Appendices
+15.  Appendices
 
-13.1.  Comparison with draft-truskovsky-lamps-pq-hybrid-x509
+15.1.  Comparison with draft-truskovsky-lamps-pq-hybrid-x509
 
    EDNOTE: This section will explain the differences from
    [I-D.truskovsky-lamps-pq-hybrid-x509].  IPR Claims should be
@@ -690,7 +746,7 @@ Internet-Draft               Composite Certs               December 2018
 
    (MO): Move to appendix, or to a supporting document?
 
-14.  Contributors
+16.  Contributors
 
    EDNOTE: This section includes the contributors of this draft so the
    authors in the first page do not exceed five and thus violate
@@ -709,14 +765,14 @@ Internet-Draft               Composite Certs               December 2018
    We are grateful to all, including any contributors who may have been
    inadvertently omitted from this list.
 
-15.  Acknowledgenents
+17.  Acknowledgenents
 
    EDNOTE: this section include all those that need to be acknowledged
    in the draft
 
-16.  References
+18.  References
 
-16.1.  Normative References
+18.1.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -725,9 +781,9 @@ Internet-Draft               Composite Certs               December 2018
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                [Page 13]
+Kampanakis (Editor)       Expires July 15, 2019                [Page 14]
 
-Internet-Draft               Composite Certs               December 2018
+Internet-Draft               Composite Certs                January 2019
 
 
    [RFC2986]  Nystrom, M. and B. Kaliski, "PKCS #10: Certification
@@ -745,7 +801,7 @@ Internet-Draft               Composite Certs               December 2018
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-16.2.  Informative References
+18.2.  Informative References
 
    [I-D.truskovsky-lamps-pq-hybrid-x509]
               Truskovsky, A., Geest, D., Fluhrer, S., Kampanakis, P.,
@@ -781,4 +837,4 @@ Author's Address
 
 
 
-Kampanakis (Editor)       Expires June 29, 2019                [Page 14]
+Kampanakis (Editor)       Expires July 15, 2019                [Page 15]


### PR DESCRIPTION
The previous draft re-defined existing X.509 certificate fields.  This
commit defines new public key and signature formats only, so that the
original field definitions can be used.  Other cosmetic changes were
made as well.  Sections 7 and later still need to be updated to reflect
the changes made in this commit.